### PR TITLE
feat(taptic): gesture control for selection events.

### DIFF
--- a/src/ios/TapticEngine.h
+++ b/src/ios/TapticEngine.h
@@ -12,4 +12,8 @@
 - (void) strongBoom:(CDVInvokedUrlCommand*)command;
 - (void) burst:(CDVInvokedUrlCommand*)command;
 
+// This property stores a selection feedback generator during
+// gestures, as per https://developer.apple.com/reference/uikit/uifeedbackgenerator#2555399
+@property UISelectionFeedbackGenerator *selectionGenerator;
+
 @end

--- a/www/TapticEngine.js
+++ b/www/TapticEngine.js
@@ -32,5 +32,14 @@ TapticEngine.prototype.impact = function (options, onSuccess, onFail) {
   exec(onSuccess, onFail, "TapticEngine", "impact", [options]);
 };
 
+TapticEngine.prototype.gestureSelectionStart = function (onSuccess, onFail) {
+  exec(onSuccess, onFail, "TapticEngine", "gestureSelectionStart", []);
+};
+TapticEngine.prototype.gestureSelectionChanged = function (onSuccess, onFail) {
+  exec(onSuccess, onFail, "TapticEngine", "gestureSelectionChanged", []);
+};
+TapticEngine.prototype.gestureSelectionEnd = function (onSuccess, onFail) {
+  exec(onSuccess, onFail, "TapticEngine", "gestureSelectionEnd", []);
+};
 
 module.exports = new TapticEngine();


### PR DESCRIPTION
Per Apple's docs on the taptic engine, if selection is going to be triggered during a gesture, the gesture should be prepared first and then not rebuilt each time. This leads to a much smoother taptic UX.

https://developer.apple.com/reference/uikit/uifeedbackgenerator#2555399